### PR TITLE
Fix slope calc for vertical lines

### DIFF
--- a/GeometryReader/Final/AppleWatchHome/AppleWatchHome/Apple Watch/AppleWatchView.swift
+++ b/GeometryReader/Final/AppleWatchHome/AppleWatchHome/Apple Watch/AppleWatchView.swift
@@ -152,7 +152,16 @@ struct AppleWatchView: View {
     }
 
     func slope(p1: CGPoint, p2: CGPoint) -> CGFloat {
-        return (p2.y - p1.y)/(p2.x - p1.x)
+        let deltaX = p2.x - p1.x
+
+        // Avoid NaN results when both points share the same X position.
+        // A vertical line has an undefined slope so we model it as
+        // a very large value using `.infinity`.
+        if deltaX == 0 {
+            return .infinity
+        }
+
+        return (p2.y - p1.y) / deltaX
     }
 
     func angle(slope: CGFloat) -> CGFloat {


### PR DESCRIPTION
## Summary
- handle vertical line cases in slope calculation to avoid NaN

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6840bc41dcd083259606277df871a4b7